### PR TITLE
Update meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
     fn: pydusa-{{ branch }}.tar.gz
 
 build:
-    number: 16
+    number: 17
     skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
Replaced the string "python2.7/site-packages/"  to  "python3.7/site-packages" in order to make it compatible with code running in python3. 

Right now the code in python 3 most likely crashes because it is not able to replace the string the way it should.

Change build number to enable the new changes